### PR TITLE
BLD/CLN: Isolate dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ before_install:
 install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - conda update conda --yes
-  - conda create -n testenv --yes pip nose python=$TRAVIS_PYTHON_VERSION lmfit xraylib numpy scipy scikit-image netcdf4 six coverage
+  - conda create -n testenv --yes pip nose python=$TRAVIS_PYTHON_VERSION xraylib numpy scipy scikit-image netcdf4 six coverage
   - source activate testenv
+  - pip install lmfit==0.8.1
   - python setup.py install
   - pip install coveralls
   - pip install codecov

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include versioneer.py
 include skxray/_version.py
+include requirements.txt
+include optional-requirements.txt

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
     - six
     - xraylib
     - scikit-image
-    - lmfit
-    - netcdf4
+    - lmfit =0.8.1
+    - netcdf4  # optional, required for skxray.io
 
 test:
   requires:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -56,11 +56,14 @@ Essential Dependencies:
 
 * python (both 2 and 3 are supported)
 * setuptools
-* numpy
-* scipy
 * six
-* xraylib
+* numpy
+
+Optional Dependencies:
+
+* scipy
 * scikit-image
+* xraylib
 * lmfit
 * netcdf4
 

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,0 +1,5 @@
+lmfit==0.8.1
+scipy
+scikit-image
+xraylib
+netCDF4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+setuptools
+six
+numpy

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     packages=setuptools.find_packages(exclude=['doc']),
     include_dirs=[np.get_include()],
     package_data={'skxray.core.constants': ['data/*.dat']},
+    install_requires=['six', 'numpy'],  # essential deps only
     ext_modules=ext_modules,
     url='http://github.com/scikit-xray/scikit-xray',
     keywords='Xray Analysis',

--- a/skxray/core/constants/basic.py
+++ b/skxray/core/constants/basic.py
@@ -38,7 +38,7 @@
 ########################################################################
 from __future__ import absolute_import, division, print_function
 import six
-from collections import namedtuple, Mapping
+from collections import namedtuple
 import functools
 import os
 import logging

--- a/skxray/core/tests/test_stats.py
+++ b/skxray/core/tests/test_stats.py
@@ -1,0 +1,17 @@
+from skxray.core.stats import statistics_1D
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+
+
+def test_statistics_1D():
+    # set up simple data
+    x = np.linspace(0, 1, 100)
+    y = np.arange(100)
+    nx = 10
+    # make call
+    edges, val = statistics_1D(x, y, nx=nx)
+    # check that values are as expected
+    assert_array_almost_equal(edges,
+                              np.linspace(0, 1, nx + 1, endpoint=True))
+    assert_array_almost_equal(val,
+                              np.sum(y.reshape(nx, -1), axis=1)/10.)

--- a/skxray/core/tests/test_utils.py
+++ b/skxray/core/tests/test_utils.py
@@ -66,18 +66,6 @@ def test_bin_1D():
                        np.ones(nx) * 10)
 
 
-def test_statistics_1D():
-    # set up simple data
-    x = np.linspace(0, 1, 100)
-    y = np.arange(100)
-    nx = 10
-    # make call
-    edges, val = core.statistics_1D(x, y, nx=nx)
-    # check that values are as expected
-    assert_array_almost_equal(edges,
-                              np.linspace(0, 1, nx + 1, endpoint=True))
-    assert_array_almost_equal(val,
-                              np.sum(y.reshape(nx, -1), axis=1)/10.)
 def test_bin_1D_2():
     """
     Test for appropriate default value handling

--- a/skxray/core/utils.py
+++ b/skxray/core/utils.py
@@ -47,7 +47,6 @@ import sys
 
 from collections import namedtuple, MutableMapping, defaultdict, deque
 import numpy as np
-import scipy.stats
 from itertools import tee
 
 import logging
@@ -600,51 +599,6 @@ def bin_1D(x, y, nx=None, min_x=None, max_x=None):
     count, _ = np.histogram(a=x, bins=bins)
     # return the three arrays
     return bins, val, count
-
-
-def statistics_1D(x, y, stat='mean', nx=None, min_x=None, max_x=None):
-    """
-    Bin the values in y based on their x-coordinates
-
-    Parameters
-    ----------
-    x : array
-        position
-    y : array
-        intensity
-    stat: str or func, optional
-        statistic to be used on the binned values defaults to mean
-        see scipy.stats.binned_statistic
-    nx : integer, optional
-        number of bins to use defaults to default bin value
-    min_x : float, optional
-        Left edge of first bin defaults to minimum value of x
-    max_x : float, optional
-        Right edge of last bin defaults to maximum value of x
-
-    Returns
-    -------
-    edges : array
-        edges of bins, length nx + 1
-
-    val : array
-        statistics of values in each bin, length nx
-    """
-
-    # handle default values
-    if min_x is None:
-        min_x = np.min(x)
-    if max_x is None:
-        max_x = np.max(x)
-    if nx is None:
-        nx = _defaults["bins"]
-
-    # use a weighted histogram to get the bin sum
-    bins = np.linspace(start=min_x, stop=max_x, num=nx+1, endpoint=True)
-
-    val, _, _ = scipy.stats.binned_statistic(x, y, statistic=stat, bins=bins)
-    # return the two arrays
-    return bins, val
 
 
 def radial_grid(center, shape, pixel_size=None):


### PR DESCRIPTION
* Do a little more to isolate parts of the code that require particular dependencies from those that work just fine with numpy alone.
* Add a `requirements.txt `and an `optional-requirements.txt` to clarify dependencies for users.
* Also split essential and optional dependencies in docs.
* Pin the version of lmfit to 0.8.1. We are broken on 0.8.2 and 0.8.3 (latest) and no one has noticed. @licode can you look at this?