### PR TITLE
MNT: Pin lmfit to 0.8.3 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - conda config --set always_yes true
   - conda update conda
   - conda create -n testenv pip nose python=$TRAVIS_PYTHON_VERSION numpy scipy=0.15.1 scikit-image six coverage
-  - conda install -n testenv -c scikit-xray xraylib lmfit netcdf4
+  - conda install -n testenv -c scikit-xray xraylib lmfit=0.8.3 netcdf4
   - source activate testenv
   - python setup.py install
   - pip install coveralls


### PR DESCRIPTION
This is required because there were breaking changes in lmfit
between minor versions 8 and 9 that our code exposes in lmfit